### PR TITLE
Add Protobuf example

### DIFF
--- a/tests/.bazelrc
+++ b/tests/.bazelrc
@@ -1,5 +1,5 @@
 # Alias
-build:cpp20 --cxxopt="-std=c++20"
+build:c++20 --cxxopt="-std=c++20"
 
 build:llvm_toolchain --extra_toolchains=//external_toolchains:llvm_toolchain
 
@@ -7,6 +7,6 @@ build:verbose_all --cxxopt="--verbose" --sandbox_debug -s --verbose_failures
 build:verbose_bazel --sandbox_debug -s
 build:verbose_cpp --cxxopt="--verbose"
 
-build:clang_tidy --config=llvm_toolchain --config=cpp20 \
+build:clang_tidy --config=llvm_toolchain --config=c++20 \
     --aspects @devops.bazel_infrastructure//toolchains/cpp/clang_tidy:clang_tidy.bzl%clang_tidy_aspect \
     --output_groups=report

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -7,3 +7,4 @@ local_path_override(
 )
 
 bazel_dep(name = "googletest", version = "1.14.0")
+bazel_dep(name = "protobuf", version = "27.2")

--- a/tests/cpp/my_hello/lib/src/bar.cpp
+++ b/tests/cpp/my_hello/lib/src/bar.cpp
@@ -1,4 +1,4 @@
-#include "../bar.h"
+#include "cpp/my_hello/lib/bar.h"
 
 std::int32_t times(const std::int32_t a, const std::int32_t b)
 {

--- a/tests/cpp/my_hello/lib/src/foo.cpp
+++ b/tests/cpp/my_hello/lib/src/foo.cpp
@@ -1,4 +1,4 @@
-#include "../foo.h"
+#include "cpp/my_hello/lib/foo.h"
 
 void Foo::add(const int a)
 {

--- a/tests/cpp/my_hello/lib/src/sys_info.cpp
+++ b/tests/cpp/my_hello/lib/src/sys_info.cpp
@@ -1,4 +1,4 @@
-#include "../sys_info.h"
+#include "cpp/my_hello/lib/sys_info.h"
 
 #include <iostream>
 

--- a/tests/cpp/protobuf/BUILD.bazel
+++ b/tests/cpp/protobuf/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "msg",
+    srcs = ["msg.proto"],
+    deps = ["@protobuf//:any_proto"],
+)
+
+# This rule converts our .proto file into the C++ specific .h and .cc files.
+cc_proto_library(
+    name = "msg_proto_cpplib",
+    deps = [":msg"],
+)
+
+cc_binary(
+    name = "main",
+    srcs = ["main.cpp"],
+    deps = [":msg_proto_cpplib"],
+)

--- a/tests/cpp/protobuf/main.cpp
+++ b/tests/cpp/protobuf/main.cpp
@@ -1,0 +1,10 @@
+#include "cpp/protobuf/msg.pb.h"
+
+int main(int argc, char* argv[])
+{
+    msg::Thing thing{};
+    thing.set_name("ded");
+    thing.set_code(10);
+
+    return 0;
+}

--- a/tests/cpp/protobuf/msg.proto
+++ b/tests/cpp/protobuf/msg.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package msg;
+
+import "google/protobuf/any.proto";
+
+message Thing {
+    string name = 1;
+    int32 code = 2;
+}

--- a/toolchains/cpp/build_tools/llvm.linux.aarch64/llvm_toolchain_config.bzl
+++ b/toolchains/cpp/build_tools/llvm.linux.aarch64/llvm_toolchain_config.bzl
@@ -30,6 +30,7 @@ def _create_llvm_toolchain_config(llvm_dir, llvm_major_version, sysroot):
         "abi_libc_version": _NOT_USED,  # "glibc_unknown",
         "cxx_builtin_include_directories": [
             paths.join(llvm_dir, "include/c++/v1"),
+            paths.join(llvm_dir, "include/aarch64-unknown-linux-gnu/c++/v1".format(llvm_major_version)),
             paths.join(llvm_dir, "lib/clang/{}/include".format(llvm_major_version)),
             paths.join(sysroot, "usr/include"),
         ],

--- a/toolchains/cpp/build_tools/llvm.macosx.aarch64/llvm_toolchain_config.bzl
+++ b/toolchains/cpp/build_tools/llvm.macosx.aarch64/llvm_toolchain_config.bzl
@@ -23,7 +23,7 @@ def _create_llvm_toolchain_config(llvm_dir, llvm_major_version, sysroot):
         "cpu": _NOT_USED,  # "darwin",
         "compiler": _NOT_USED,  # "clang",
         "host_system_name": _NOT_USED,  # "aarch64",
-        "target_system_name": _NOT_USED,  # "NONE",
+        "target_system_name": _NOT_USED, # "aarch64-apple-macosx"
         "target_libc": "macosx",
         "abi_version": _NOT_USED,  # "darwin_aarch64",
         "abi_libc_version": _NOT_USED,  # "darwin_aarch64",
@@ -31,6 +31,7 @@ def _create_llvm_toolchain_config(llvm_dir, llvm_major_version, sysroot):
             paths.join(llvm_dir, "include/c++/v1"),
             paths.join(llvm_dir, "lib/clang/{}/include".format(llvm_major_version)),
             paths.join(sysroot, "usr/include"),
+            paths.join(sysroot, "System/Library/Frameworks"),
         ],
         "tool_paths": {
             "ar": paths.join(llvm_dir, "bin/llvm-libtool-darwin"),
@@ -44,6 +45,7 @@ def _create_llvm_toolchain_config(llvm_dir, llvm_major_version, sysroot):
             "strip": paths.join(llvm_dir, "bin/llvm-strip"),
         },
         "compile_flags": [
+            # "--target=aarch64-apple-macosx",
             # Security
             "-U_FORTIFY_SOURCE",  # https://github.com/google/sanitizers/issues/247
             "-fstack-protector",
@@ -53,6 +55,7 @@ def _create_llvm_toolchain_config(llvm_dir, llvm_major_version, sysroot):
             "-Wall",
             "-Wthread-safety",
             "-Wself-assign",
+            "-fno-define-target-os-macros", # Prevents the definition of TARGET_OS_OSX
         ],
         "dbg_compile_flags": ["-g", "-fstandalone-debug"],
         "opt_compile_flags": [
@@ -77,7 +80,8 @@ def _create_llvm_toolchain_config(llvm_dir, llvm_major_version, sysroot):
             "-lc++abi",
             "-lunwind",
             # "-lm", # TODO: link math library.Disable for now, not necessary at the moment.
-            "-L{}lib".format(llvm_dir),  # Or equivalent as `--library-directory=<lib>`
+            "-L{}lib".format(llvm_dir),
+            # "-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib",  # Or equivalent as `--library-directory=<lib>`
             # "-Bstatic",  # NOTE: Disabled for now, don't know how this flag affects the linking.
             # "-Bdynamic_t",  # NOTE: Disabled for now, don't know how this flag affects the linking.
         ],


### PR DESCRIPTION
The compiler option `-fno-define-target-os-macros` is added to make zlib (which is depended by protobuf) to compile.